### PR TITLE
Don't include blocked pairs from the beginning

### DIFF
--- a/xchange/Bittrex.php
+++ b/xchange/Bittrex.php
@@ -151,7 +151,8 @@ class Bittrex extends Exchange {
       $tradeable = $market[ 'MarketCurrency' ];
       $currency = $market[ 'BaseCurrency' ];
 
-      if ( !Config::isCurrency( $currency ) ) {
+      if ( !Config::isCurrency( $currency ) ||
+           Config::isBlocked( $tradeable ) ) {
         continue;
       }
 

--- a/xchange/Poloniex.php
+++ b/xchange/Poloniex.php
@@ -183,7 +183,8 @@ class Poloniex extends Exchange {
       $tradeable = $split[ 1 ];
       $currency = $split[ 0 ];
 
-      if ( !Config::isCurrency( $currency ) ) {
+      if ( !Config::isCurrency( $currency ) ||
+           Config::isBlocked( $tradeable ) ) {
         continue;
       }
 


### PR DESCRIPTION
This helps properly honoring the expert.max-pairs-per-run setting
by removing the pairs where the tradeable asset is blocked in the
config file when refreshing the list of supported pairs from the
exchanges.