### PR TITLE
Format the nonce integers using non-scientific notation

### DIFF
--- a/xchange/Bittrex.php
+++ b/xchange/Bittrex.php
@@ -359,7 +359,7 @@ class Bittrex extends Exchange {
     $nonce = $this->nonce();
 
     $req[ 'apikey' ] = $key;
-    $req[ 'nonce' ] = $nonce;
+    $req[ 'nonce' ] = sprintf( "%ld", $nonce );
 
     $uri = 'https://bittrex.com/api/v1.1/' . $method . '?' . http_build_query( $req );
     $sign = hash_hmac( 'sha512', $uri, $secret );

--- a/xchange/Poloniex.php
+++ b/xchange/Poloniex.php
@@ -354,7 +354,7 @@ class Poloniex extends Exchange {
 
     $req[ 'command' ] = $command;
     //$req[ 'nonce' ] = $mt[1].substr($mt[0], 2, 6);
-    $req['nonce'] = $nonce;
+    $req['nonce'] = sprintf( "%ld", $nonce );
     // generate the POST data string
     $post_data = http_build_query( $req, '', '&' );
     $sign = hash_hmac( 'sha512', $post_data, $secret );


### PR DESCRIPTION
This is needed for HHVM compatibility.  With this fix, main.php can
be successfully run under HHVM.