### PR TITLE
When refreshing coin pairs, only use tradeables in a wallet

### DIFF
--- a/Arbitrator.php
+++ b/Arbitrator.php
@@ -10,6 +10,7 @@ class Arbitrator {
   private $coinManager;
   //
   private $nextCoinUpdate = 0;
+  private $walletsRefreshed = false;
 
   function __construct( $exchanges ) {
     $this->exchanges = $exchanges;
@@ -30,6 +31,9 @@ class Arbitrator {
     Config::refresh();
 
     if ( time() > $this->nextCoinUpdate ) {
+      if (!$this->walletsRefreshed) {
+        $this->refreshWallets();
+      }
       $this->refreshCoinPairs();
       $this->nextCoinUpdate = time() + 3600;
     }
@@ -410,6 +414,8 @@ class Arbitrator {
     foreach ( $this->exchanges as $exchange ) {
       $exchange->refreshWallets();
     }
+
+    $this->walletsRefreshed = true;
 
   }
 

--- a/CoinManager.php
+++ b/CoinManager.php
@@ -709,7 +709,7 @@ class CoinManager {
     logg( "Transfering $amount $coin " . $source->getName() . " => " . $target->getName() );
     $address = $target->getDepositAddress( $coin );
     if ( is_null( $address ) || strlen( trim( $address ) ) == 0 ) {
-      logg( "Invalid deposit address for " . $target->getName() );
+      logg( "Invalid deposit address for " . $target->getName() . ", received: ". $address );
 
       return;
     }

--- a/xchange/Bittrex.php
+++ b/xchange/Bittrex.php
@@ -139,6 +139,11 @@ class Bittrex extends Exchange {
 
   public function refreshExchangeData() {
 
+    if (empty($this->wallets)) {
+      logg("Attempting to refresh exchange data before wallets are initialized");
+      throw new Exception("wallets not initialized");
+    }
+
     $pairs = [ ];
     $markets = $this->queryMarkets();
     $currencies = $this->queryCurrencies();
@@ -151,7 +156,8 @@ class Bittrex extends Exchange {
       $tradeable = $market[ 'MarketCurrency' ];
       $currency = $market[ 'BaseCurrency' ];
 
-      if ( !Config::isCurrency( $currency ) ) {
+      if ( !Config::isCurrency( $currency ) ||
+           !in_array( $tradeable, array_keys( $this->wallets ) ) ) {
         continue;
       }
 

--- a/xchange/Poloniex.php
+++ b/xchange/Poloniex.php
@@ -172,6 +172,11 @@ class Poloniex extends Exchange {
 
   public function refreshExchangeData() {
 
+    if (empty($this->wallets)) {
+      logg("Attempting to refresh exchange data before wallets are initialized");
+      throw new Exception("wallets not initialized");
+    }
+
     $pairs = [ ];
     $markets = $this->queryTicker();
 
@@ -183,7 +188,8 @@ class Poloniex extends Exchange {
       $tradeable = $split[ 1 ];
       $currency = $split[ 0 ];
 
-      if ( !Config::isCurrency( $currency ) ) {
+      if ( !Config::isCurrency( $currency ) ||
+           !in_array( $tradeable, array_keys( $this->wallets ) ) ) {
         continue;
       }
 


### PR DESCRIPTION
This fixes #11.