### PR TITLE
Generate a new address if there's no deposit address for Poloniex

### DIFF
--- a/xchange/Poloniex.php
+++ b/xchange/Poloniex.php
@@ -73,7 +73,12 @@ class Poloniex extends Exchange {
 
   public function getDepositAddress( $coin ) {
     if ( !key_exists( $coin, $this->depositAddresses ) ) {
-      return null;
+      $result = $this->queryAPI( 'generateNewAddress',
+                                 [ 'currency' => $coin ] );
+      if ($result[ 'success' ] !== 1) {
+        return null;
+      }
+      $this->depositAddresses[ $coin ] = $result[ 'response' ];
     }
 
     $address = $this->depositAddresses[ $coin ];


### PR DESCRIPTION
This fixes #13.  Note that $this->depositAddresses, as initialized
by refreshExchangeData() only includes entries for wallets with a
non-zero balance.